### PR TITLE
Added pass for empty domoticz configuration

### DIFF
--- a/gigasetelements/gigasetelements.py
+++ b/gigasetelements/gigasetelements.py
@@ -214,6 +214,9 @@ def configure():
                 url_domo = 'http://' + authstring + dconfig['ip'] + ':' + dconfig['port']
             except Exception:
                 log('Configuration'.ljust(17) + ' | ' + 'ERROR'.ljust(8) + ' | Domoticz setting(s) incorrect and/or missing', 3, 1)
+
+                # MarkO: We want to check later if there was or was not a succesful domoticz configuration
+                url_domo = False
         log('Configuration'.ljust(17) + ' | ' + color('loaded'.ljust(8)) + ' | ' + args.config)
         if args.username is None:
             args.username = config.get('accounts', 'username')
@@ -549,18 +552,21 @@ def monitor():
 def domoticz(event, sid, friendly):
     """Push events to domoticz server."""
     global status_data
-    if event in ['open', 'close', 'sirenon', 'sirenoff', 'on', 'off', 'movement', 'motion', 'button1', 'button2', 'button3', 'button4']:
-        if event in ['close', 'sirenoff', 'off']:
-            cmd = 'off'
+
+    # MarkO: Only run domoticz commands if there is an actual domoticz configuration
+    if url_domo:
+        if event in ['open', 'close', 'sirenon', 'sirenoff', 'on', 'off', 'movement', 'motion', 'button1', 'button2', 'button3', 'button4']:
+            if event in ['close', 'sirenoff', 'off']:
+                cmd = 'off'
+            else:
+                cmd = 'on'
+            restget(url_domo + URL_SWITCH + cmd.title() + '&idx=' + dconfig[sid])
         else:
-            cmd = 'on'
-        restget(url_domo + URL_SWITCH + cmd.title() + '&idx=' + dconfig[sid])
-    else:
-        status_data = restget(URL_HEALTH)
-        restget(url_domo + URL_ALERT + dconfig[basestation_data[0]['id'].lower()] + '&nvalue=' +
-                LEVEL.get(status_data['system_health'], '3') + '&svalue=' + friendly + ' | ' + event)
-    sys.stdout.write("\033[F")
-    sys.stdout.write("\033[K")
+            status_data = restget(URL_HEALTH)
+            restget(url_domo + URL_ALERT + dconfig[basestation_data[0]['id'].lower()] + '&nvalue=' +
+                    LEVEL.get(status_data['system_health'], '3') + '&svalue=' + friendly + ' | ' + event)
+        sys.stdout.write("\033[F")
+        sys.stdout.write("\033[K")
     return
 
 

--- a/gigasetelements/gigasetelements.py
+++ b/gigasetelements/gigasetelements.py
@@ -214,8 +214,6 @@ def configure():
                 url_domo = 'http://' + authstring + dconfig['ip'] + ':' + dconfig['port']
             except Exception:
                 log('Configuration'.ljust(17) + ' | ' + 'ERROR'.ljust(8) + ' | Domoticz setting(s) incorrect and/or missing', 3, 1)
-
-                # MarkO: We want to check later if there was or was not a succesful domoticz configuration
                 url_domo = False
         log('Configuration'.ljust(17) + ' | ' + color('loaded'.ljust(8)) + ' | ' + args.config)
         if args.username is None:
@@ -552,8 +550,6 @@ def monitor():
 def domoticz(event, sid, friendly):
     """Push events to domoticz server."""
     global status_data
-
-    # MarkO: Only run domoticz commands if there is an actual domoticz configuration
     if url_domo:
         if event in ['open', 'close', 'sirenon', 'sirenoff', 'on', 'off', 'movement', 'motion', 'button1', 'button2', 'button3', 'button4']:
             if event in ['close', 'sirenoff', 'off']:


### PR DESCRIPTION
The monitor crashed on an empty domoticz configuration: the url_domo variable was not initialized when an exception was thrown. I made a quick fix by initalizing to an empty value and checking that before sending domoticz requests.